### PR TITLE
Gjør hindring av Spotlight-indeksering kompatibel med Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,13 @@
     "pretty-please": "pretty-quick --staged",
     "pretty-commit": "pretty-quick --staged --pattern \"**/*.*(ts|tsx|js)\"",
     "prepare": "husky install",
-    "preinstall": "mkdir -p ./node_modules && touch ./node_modules/.metadata_never_index",
+    "postinstall": "cross-os postinstall",
     "test:int": "testcafe firefox --hostname localhost tests/ --skip-js-errors --dev --assertion-timeout 300"
+  },
+  "cross-os": {
+    "postinstall": {
+      "darwin": "mkdir -p ./node_modules && touch ./node_modules/.metadata_never_index"
+    }
   },
   "engines": {
     "node": ">=14",
@@ -114,6 +119,7 @@
     "@types/react-modal": "3.x",
     "@types/react-router-dom": "5.x",
     "@types/uuid": "8.x",
+    "cross-os": "1.5.0",
     "eslint-plugin-testcafe": "^0.2.1",
     "eslint-plugin-typescript": "^0.14.0",
     "husky": "6.x",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint src/**/*.ts*",
     "lint:fix": "eslint src/**/*.ts* --fix",
     "pretty-please": "pretty-quick --staged",
-    "pretty-commit": "pretty-quick --staged --pattern '**/*.*(ts|tsx|js)'",
+    "pretty-commit": "pretty-quick --staged --pattern \"**/*.*(ts|tsx|js)\"",
     "prepare": "husky install",
     "preinstall": "mkdir -p ./node_modules && touch ./node_modules/.metadata_never_index",
     "test:int": "testcafe firefox --hostname localhost tests/ --skip-js-errors --dev --assertion-timeout 300"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5622,6 +5622,11 @@ cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-os@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cross-os/-/cross-os-1.5.0.tgz#7ffabbe9a12b4618336634db09c84ac925847e10"
+  integrity sha512-zjiZPGuzghQzjcymlI7oUh5iDCRlhfi9UBqkCmqxnnx/5B+K1+BgIm0YU+fua7GC+RoeywS0qsoEavRM+Kahxw==
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"


### PR DESCRIPTION
Jeg fant ikke en god måte å gjøre denne endringen på som fremdeles lagde `.metadata_never_index`-filen _før_ pakkene installeres. Jeg kan ikke stort om Spotlight, men det fører nok til at Spotlight starter å indeksere filene, så selve installasjonen vil være mer intensiv. Derimot vil ikke filene dukke opp i søk, såvidt jeg har forstått det.